### PR TITLE
feat(ticket): add list command with Search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A small TypeScript CLI for exploring Zendesk tickets from your terminal. Inspire
 - Filter JSON by fields (supports dotted paths and array selectors like `comments[].id`)
 - List available JSON fields for quick discovery
 - Open a ticket in the browser
+- List tickets with flexible filters (assignee, group, status, date, query)
 
 ## Requirements
 
@@ -97,6 +98,48 @@ zd ticket view 309438 --template "{{id}} {{status}} {{subject}}"
 
 # open in browser
 zd ticket view 309438 --web
+```
+
+### `ticket list`
+
+List tickets using Zendesk Search API with familiar gh-style filters.
+
+```bash
+zd ticket list [flags]
+```
+
+Flags:
+
+- `--assignee <me|email|id>` – filter by assignee (default: `me`)
+- `--group <id|name>` – filter by group (name auto-resolves to id)
+- `--status <list>` – comma-separated statuses: `new,open,pending,on-hold,solved,closed` (default: `new,open,pending,on-hold`)
+- `--updated-since <ISO>` – only tickets updated since date (e.g., `2025-01-01`)
+- `--query <string>` – additional free-text query
+- `--sort <field>` – `created|updated|priority` (default: `updated`)
+- `--order <order>` – `asc|desc` (default: `desc`)
+- `--limit <N>` – per page (default: `30`), `--page <N>` – page number (default: `1`)
+- `-j, --json` – output raw JSON
+- `--fields <fields>` – comma‑separated fields to include in JSON output
+- `-t, --template <string>` – format JSON with a simple template
+- `-w, --web` – open the same search in the browser
+
+Examples:
+
+```bash
+# default: my open tickets, most recently updated
+zd ticket list
+
+# by group (name will be resolved to id)
+zd ticket list --group "Support" --status open,pending --limit 20
+
+# by assignee and updated since date
+zd ticket list --assignee me --updated-since 2025-01-01
+
+# open the same search in Zendesk agent UI
+zd ticket list --group "Support" --status open --web
+
+# JSON with selected fields
+zd ticket list --json --fields "id,subject,status,assignee_id,updated_at" --limit 5
 ```
 
 ## Development

--- a/src/commands/ticket.test.ts
+++ b/src/commands/ticket.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { collectKeyPaths, getPath } from "../utils/jsonPaths";
+import { buildTicketSearchQuery } from "../utils/searchQuery";
 
 describe("ticket command utilities", () => {
   it("collectKeyPaths should list nested keys and array markers", () => {
@@ -48,5 +49,29 @@ describe("ticket command utilities", () => {
     expect(getPath(sample, "ticket.arr[].x")).toBe(42);
     expect(getPath(sample, "comments[].id")).toBe(10);
     expect(getPath(sample, "missing.key")).toBeUndefined();
+  });
+
+  it("buildTicketSearchQuery emits defaults when no filters provided", () => {
+    const { tokens, query } = buildTicketSearchQuery({});
+    expect(tokens).toContain("type:ticket");
+    expect(tokens).toContain("assignee:me");
+    expect(tokens).toContain("status:new");
+    expect(tokens).toContain("status:open");
+    expect(tokens).toContain("status:pending");
+    expect(tokens).toContain("status:on-hold");
+    expect(query).toContain("type:ticket");
+  });
+
+  it("buildTicketSearchQuery respects explicit filters and quotes group names", () => {
+    const { tokens, query } = buildTicketSearchQuery({
+      group: "technical support",
+      status: "open,pending",
+    });
+    // no default assignee when explicit filters exist
+    expect(tokens.find((t) => t.startsWith("assignee:"))).toBeUndefined();
+    expect(tokens).toContain('group:"technical support"');
+    expect(tokens).toContain("status:open");
+    expect(tokens).toContain("status:pending");
+    expect(query).toContain('group:"technical support"');
   });
 });

--- a/src/commands/ticket.ts
+++ b/src/commands/ticket.ts
@@ -3,9 +3,137 @@ import chalk from "chalk";
 
 import { ZendeskClient } from "../libs/zendesk";
 import { collectKeyPaths, getPath } from "../utils/jsonPaths";
+import { buildTicketSearchQuery } from "../utils/searchQuery";
 
 export const ticketCmd = new Command("ticket").description("Ticket command");
 
+const listTicketCmd = new Command("list")
+  .description("List tickets using Zendesk search filters")
+  .option("--assignee <me|email|id>", "Filter by assignee")
+  .option("--group <id|name>", "Filter by group")
+  .option(
+    "--status <list>",
+    "Comma separated statuses: new,open,pending,on-hold,solved,closed"
+  )
+  .option("--updated-since <ISO>", "Only tickets updated since ISO date")
+  .option("--query <string>", "Additional free-text query")
+  .option("--sort <field>", "Sort by created|updated|priority", "updated")
+  .option("--order <order>", "asc|desc", "desc")
+  .option("--limit <N>", "Results per page", "30")
+  .option("--page <N>", "Page number", "1")
+  .option("-j, --json", "Output raw JSON")
+  .option("--fields <fields>", "Comma-separated fields for JSON output")
+  .option("-t, --template <string>", "Format JSON using a template")
+  .option("-w, --web", "Open the search in the browser")
+  .action(async (options) => {
+    let client: ZendeskClient;
+    try {
+      client = ZendeskClient.fromEnv();
+    } catch (err) {
+      console.error(
+        chalk.red(
+          `${(err as Error).message}\nExpected env: ZENDESK_SUB_DOMAIN and ZENDESK_API_KEY`
+        )
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    // Resolve group name to id if possible, otherwise leave it to the query builder to quote
+    let groupFilter: string | undefined = options.group;
+    if (groupFilter && !/^\d+$/.test(String(groupFilter))) {
+      const resolved = await client.getGroupIdByName(String(groupFilter));
+      if (resolved) groupFilter = String(resolved);
+    }
+
+    const { query } = buildTicketSearchQuery({
+      assignee: options.assignee,
+      group: groupFilter ?? options.group,
+      status: options.status,
+      updatedSince: options.updatedSince,
+      query: options.query,
+    });
+
+    if (options.web) {
+      const url = client.toWebSearchUrl(query);
+      await import("node:child_process").then(({ exec }) =>
+        exec(
+          `${process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open"} ${url}`
+        )
+      );
+      return;
+    }
+
+    const sortBy = ["created", "updated", "priority"].includes(
+      String(options.sort)
+    )
+      ? (options.sort as "created" | "updated" | "priority")
+      : "updated";
+    const order = String(options.order) === "asc" ? "asc" : "desc";
+    const perPage = Number.parseInt(String(options.limit), 10) || 30;
+    const page = Number.parseInt(String(options.page), 10) || 1;
+
+    const result = await client.searchTickets({
+      query,
+      page,
+      perPage,
+      sortBy,
+      order,
+    });
+
+    if (options.json) {
+      const payload: any = result;
+      if (options.fields) {
+        const requested = String(options.fields)
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+        const filtered = result.results.map((r) => {
+          const out: Record<string, unknown> = {};
+          for (const f of requested) {
+            if (f in r) out[f] = (r as any)[f];
+          }
+          return out;
+        });
+        console.log(JSON.stringify(filtered, null, 2));
+        return;
+      }
+      console.log(JSON.stringify(payload, null, 2));
+      return;
+    }
+
+    // Pretty table-like output
+    const rows = result.results.map((r) => {
+      const cols = [
+        String(r.id ?? "-").padEnd(8),
+        String(r.status ?? "-").padEnd(9),
+        String(r.priority ?? "-").padEnd(8),
+        String(r.assignee_id ?? "-").padEnd(12),
+        String(r.updated_at ?? "-").padEnd(24),
+        String(r.subject ?? "-")
+          .replace(/\n/g, " ")
+          .slice(0, 80),
+      ];
+      return cols.join("  ");
+    });
+    if (rows.length === 0) {
+      console.log(chalk.yellow("No tickets found."));
+      return;
+    }
+    console.log(
+      [
+        [
+          "ID".padEnd(8),
+          "STATUS".padEnd(9),
+          "PRIORITY".padEnd(8),
+          "ASSIGNEE".padEnd(12),
+          "UPDATED AT".padEnd(24),
+          "SUBJECT",
+        ].join("  "),
+        ...rows,
+      ].join("\n")
+    );
+  });
 // path helpers moved to ../utils/jsonPaths
 
 const viewTicketCmd = new Command("view")
@@ -16,15 +144,15 @@ const viewTicketCmd = new Command("view")
   .option("-w, --web", "Open the ticket in the browser")
   .option(
     "--fields <fields>",
-    "Comma-separated fields to include in JSON output",
+    "Comma-separated fields to include in JSON output"
   )
   .option(
     "-t, --template <string>",
-    "Format JSON output using a template expression",
+    "Format JSON output using a template expression"
   )
   .option(
     "--list-fields",
-    "List available JSON field paths based on the fetched payload",
+    "List available JSON field paths based on the fetched payload"
   )
   .action(
     async (
@@ -36,7 +164,7 @@ const viewTicketCmd = new Command("view")
         fields?: string;
         template?: string;
         listFields?: boolean;
-      },
+      }
     ) => {
       let client: ZendeskClient;
       try {
@@ -44,8 +172,8 @@ const viewTicketCmd = new Command("view")
       } catch (err) {
         console.error(
           chalk.red(
-            `${(err as Error).message}\nExpected env: ZENDESK_SUB_DOMAIN and ZENDESK_API_KEY`,
-          ),
+            `${(err as Error).message}\nExpected env: ZENDESK_SUB_DOMAIN and ZENDESK_API_KEY`
+          )
         );
         process.exitCode = 1;
         return;
@@ -56,8 +184,8 @@ const viewTicketCmd = new Command("view")
           const url = client.getAgentTicketUrl(id);
           await import("node:child_process").then(({ exec }) =>
             exec(
-              `${process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open"} ${url}`,
-            ),
+              `${process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open"} ${url}`
+            )
           );
           return;
         }
@@ -109,7 +237,7 @@ const viewTicketCmd = new Command("view")
                 let cur: any = root;
                 for (const p of parts) cur = cur?.[p];
                 return cur == null ? "" : String(cur);
-              },
+              }
             );
             console.log(rendered);
             return;
@@ -134,7 +262,7 @@ const viewTicketCmd = new Command("view")
             `${chalk.bold("Requester ID:")} ${t.requester_id ?? "-"}`,
             `${chalk.bold("Created:")} ${t.created_at ?? "-"}`,
             `${chalk.bold("Updated:")} ${t.updated_at ?? "-"}`,
-          ].join("\n"),
+          ].join("\n")
         );
 
         if (options.comments) {
@@ -146,7 +274,7 @@ const viewTicketCmd = new Command("view")
                 [
                   `- ${chalk.bold(String(c.id ?? "-"))} by ${c.author_id ?? "-"} at ${c.created_at ?? "-"}`,
                   `  ${String(c.body ?? "").slice(0, 200)}`,
-                ].join("\n"),
+                ].join("\n")
               );
             }
           }
@@ -155,7 +283,8 @@ const viewTicketCmd = new Command("view")
         console.error(chalk.red(`Error: ${(error as Error).message}`));
         process.exitCode = 1;
       }
-    },
+    }
   );
 
 ticketCmd.addCommand(viewTicketCmd);
+ticketCmd.addCommand(listTicketCmd);

--- a/src/libs/zendesk.ts
+++ b/src/libs/zendesk.ts
@@ -42,6 +42,25 @@ export interface TicketCommentsResponse {
   comments?: TicketCommentShape[];
 }
 
+export interface SearchTicketShape {
+  id?: number;
+  subject?: string;
+  status?: string;
+  priority?: string | null;
+  assignee_id?: number | null;
+  requester_id?: number | null;
+  group_id?: number | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface TicketSearchResponse {
+  results: SearchTicketShape[];
+  next_page?: string | null;
+  previous_page?: string | null;
+  count?: number;
+}
+
 export class ZendeskClient {
   private readonly subdomain: string;
   private readonly apiToken: string;
@@ -58,7 +77,7 @@ export class ZendeskClient {
 
     if (!subdomain) {
       throw new Error(
-        "Missing required environment variable: ZENDESK_SUB_DOMAIN",
+        "Missing required environment variable: ZENDESK_SUB_DOMAIN"
       );
     }
 
@@ -71,7 +90,7 @@ export class ZendeskClient {
 
   async getTicket(ticketId: string | number): Promise<TicketResponse> {
     const url = `https://${this.subdomain}.zendesk.com/api/v2/tickets/${encodeURIComponent(
-      String(ticketId),
+      String(ticketId)
     )}.json`;
 
     const response = await fetch(url, {
@@ -86,7 +105,7 @@ export class ZendeskClient {
       throw new Error(
         `Zendesk request failed (${response.status} ${response.statusText})${
           bodyText ? `: ${bodyText}` : ""
-        }`,
+        }`
       );
     }
 
@@ -95,10 +114,10 @@ export class ZendeskClient {
   }
 
   async getTicketComments(
-    ticketId: string | number,
+    ticketId: string | number
   ): Promise<TicketCommentsResponse> {
     const url = `https://${this.subdomain}.zendesk.com/api/v2/tickets/${encodeURIComponent(
-      String(ticketId),
+      String(ticketId)
     )}/comments.json`;
 
     const response = await fetch(url, {
@@ -113,7 +132,7 @@ export class ZendeskClient {
       throw new Error(
         `Zendesk request failed (${response.status} ${response.statusText})${
           bodyText ? `: ${bodyText}` : ""
-        }`,
+        }`
       );
     }
 
@@ -123,8 +142,72 @@ export class ZendeskClient {
 
   getAgentTicketUrl(ticketId: string | number): string {
     return `https://${this.subdomain}.zendesk.com/agent/tickets/${encodeURIComponent(
-      String(ticketId),
+      String(ticketId)
     )}`;
+  }
+
+  async searchTickets(params: {
+    query: string;
+    page?: number;
+    perPage?: number;
+    sortBy?: "created" | "updated" | "priority";
+    order?: "asc" | "desc";
+  }): Promise<TicketSearchResponse> {
+    const qp = new URLSearchParams();
+    qp.set("query", params.query);
+    if (params.page) qp.set("page", String(params.page));
+    if (params.perPage) qp.set("per_page", String(params.perPage));
+    if (params.sortBy) qp.set("order_by", params.sortBy);
+    if (params.order) qp.set("sort", params.order);
+
+    const url = `https://${this.subdomain}.zendesk.com/api/v2/search.json?${qp.toString()}`;
+    const response = await fetch(url, {
+      headers: {
+        Authorization: this.getAuthorizationHeader(),
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const bodyText = await response.text().catch(() => "");
+      throw new Error(
+        `Zendesk request failed (${response.status} ${response.statusText})${
+          bodyText ? `: ${bodyText}` : ""
+        }`
+      );
+    }
+
+    const data = (await response.json()) as TicketSearchResponse;
+    return data;
+  }
+
+  async getGroupIdByName(name: string): Promise<number | undefined> {
+    // Use incremental search for groups; match by case-insensitive name
+    const url = `https://${this.subdomain}.zendesk.com/api/v2/groups/search.json?query=${encodeURIComponent(
+      name
+    )}`;
+    const response = await fetch(url, {
+      headers: {
+        Authorization: this.getAuthorizationHeader(),
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) return undefined;
+    const body = (await response.json()) as {
+      groups?: Array<{ id: number; name: string }>;
+      next_page?: string | null;
+    };
+    const groups = body.groups ?? [];
+    const found = groups.find(
+      (g) => g.name.toLowerCase() === name.toLowerCase()
+    );
+    return found?.id;
+  }
+
+  toWebSearchUrl(query: string): string {
+    const q = encodeURIComponent(query);
+    return `https://${this.subdomain}.zendesk.com/agent/search/1?query=${q}`;
   }
 
   private getAuthorizationHeader(): string {

--- a/src/utils/searchQuery.ts
+++ b/src/utils/searchQuery.ts
@@ -1,0 +1,63 @@
+export interface TicketListFlagsLike {
+  assignee?: string | undefined;
+  group?: string | undefined; // accepts id or name; name will be quoted if contains spaces
+  status?: string | undefined; // comma-separated
+  updatedSince?: string | undefined; // ISO date
+  query?: string | undefined; // free text
+}
+
+/**
+ * Build Zendesk search tokens and query string mirroring the CLI behavior.
+ * - Always includes `type:ticket`
+ * - If no other filters provided, defaults to `assignee:me` and open-ish statuses
+ * - Multiple statuses are emitted as repeated `status:` tokens (OR behavior)
+ * - Group names with spaces are quoted
+ */
+export function buildTicketSearchQuery(flags: TicketListFlagsLike): {
+  tokens: string[];
+  query: string;
+} {
+  const tokens: string[] = ["type:ticket"];
+
+  const hasExplicitFilter = Boolean(
+    flags.assignee ||
+      flags.group ||
+      flags.status ||
+      flags.updatedSince ||
+      flags.query
+  );
+
+  // assignee
+  if (flags.assignee) {
+    const a = String(flags.assignee).trim();
+    if (a.toLowerCase() === "me") tokens.push("assignee:me");
+    else if (/^\d+$/.test(a)) tokens.push(`assignee:${a}`);
+    else tokens.push(`assignee:${a}`); // email
+  } else if (!hasExplicitFilter) {
+    tokens.push("assignee:me");
+  }
+
+  // status
+  const statusList: string[] = flags.status
+    ? String(flags.status)
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : hasExplicitFilter
+      ? []
+      : ["new", "open", "pending", "on-hold"]; // default open-ish only when no explicit filters
+
+  for (const s of statusList) tokens.push(`status:${s}`);
+
+  // group
+  if (flags.group) {
+    const g = String(flags.group).trim();
+    if (/^\d+$/.test(g)) tokens.push(`group:${g}`);
+    else tokens.push(`group:"${g.replaceAll('"', '\\"')}"`);
+  }
+
+  if (flags.updatedSince) tokens.push(`updated>=${flags.updatedSince}`);
+  if (flags.query) tokens.push(String(flags.query));
+
+  return { tokens, query: tokens.join(" ") };
+}


### PR DESCRIPTION
Add a first-class ticket listing workflow and enhance ticket viewing to mirror the GitHub CLI UX. Centralizes query building and adds tests to prevent regressions.